### PR TITLE
Move links to different section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Rock Paper Scissors
 
+🔗 [Live Preview](https://xenocidy.github.io/rock-paper-scissors/) 
+
 A website with an external javascript and CSS file that allows the user to play the game of Rock, Paper, Scissors
 with the computer. The program has the ability to determine the winner of each round and keep track of score by using 
 Document Object Model (DOM) manipulation.
 
-## How to run this program?
-You can visit [xenocidy.github.io/rock-paper-scissors/](https://xenocidy.github.io/rock-paper-scissors/) and it would prompt the program within the webpage.
-
-[Link to assignment](https://www.theodinproject.com/lessons/foundations-rock-paper-scissors)
+🔗 [Link to assignment](https://www.theodinproject.com/lessons/foundations-rock-paper-scissors)


### PR DESCRIPTION
close: https://github.com/Xenocidy/rock-paper-scissors/issues/3
This is how the Readme looks after the requested changes
<img width="1017" alt="Screen Shot 2022-10-25 at 11 17 37 PM" src="https://user-images.githubusercontent.com/111394557/197926458-496add3a-6831-4932-a4ba-15e22476b397.png">
